### PR TITLE
fix: removed docker-compose

### DIFF
--- a/Dockerfiles/requirements-infra.txt
+++ b/Dockerfiles/requirements-infra.txt
@@ -1,6 +1,5 @@
 PyMySQL
 docker
-docker-compose
 jsondiff
 netaddr
 pexpect


### PR DESCRIPTION
removed docker-cmpose as v1 is no longer supported in PyYaml